### PR TITLE
Correct the phase calculation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: compareRhythms
 Type: Package
 Title: Approaches to identify Differential Rhythmicity
-Version: 1.0.2
+Version: 1.0.3
 Author: Bharath Ananthasubramaniam
 Maintainer: Bharath Ananthasubramaniam <bharath.ananthasubramaniam@hu-berlin.deu>
 Description: This package identifies features that have altered rhythms 

--- a/R/utils.R
+++ b/R/utils.R
@@ -9,7 +9,7 @@ compute_circ_params <- function(y, t, period) {
 
   amps <- 2 * sqrt(base::colSums(fit$coefficients[-1, ]^2))
 
-  phases <- (atan2(fit$coefficients[3, ], fit$coefficients[2, ]) %% (2*pi))
+  phases <- (atan2(fit$coefficients[2, ], fit$coefficients[3, ]) %% (2*pi))
 
   return(base::cbind(amps = amps, phases = phases))
 
@@ -31,7 +31,7 @@ compute_model_params <- function(y, group_id, d=NULL, type="fit") {
                                        c("inphase", "outphase"),
                                        sep = "_"), drop=FALSE]
     amps_A <- 2 * sqrt(base::rowSums(rhy_params^2))
-    phases_A <- base::atan2(rhy_params[, 2], rhy_params[, 1]) %% (2*pi)
+    phases_A <- base::atan2(rhy_params[, 1], rhy_params[, 2]) %% (2*pi)
   } else {
     amps_A <- 0
     phases_A <- 0
@@ -43,7 +43,7 @@ compute_model_params <- function(y, group_id, d=NULL, type="fit") {
                                        c("inphase", "outphase"),
                                        sep = "_"), drop=FALSE]
     amps_B <- 2 * sqrt(base::rowSums(rhy_params^2))
-    phases_B <- base::atan2(rhy_params[, 2], rhy_params[, 1])  %% (2*pi)
+    phases_B <- base::atan2(rhy_params[, 1], rhy_params[, 2])  %% (2*pi)
   } else {
     amps_B <- 0
     phases_B <- 0
@@ -53,7 +53,7 @@ compute_model_params <- function(y, group_id, d=NULL, type="fit") {
                            colnames(coeffs)))) {
     rhy_params <- coeffs[, c("inphase", "outphase"), drop=FALSE]
     amps <- 2 * sqrt(base::rowSums(rhy_params^2))
-    phases <- base::atan2(rhy_params[, 2], rhy_params[, 1])  %% (2*pi)
+    phases <- base::atan2(rhy_params[, 1], rhy_params[, 2])  %% (2*pi)
     model_params <- base::cbind(amps, phases, amps, phases)
   } else {
     model_params <- base::cbind(amps_A, phases_A, amps_B, phases_B)


### PR DESCRIPTION
I was plotting sine curves, with the amplitude and phase calculated by the compareRhythms longitudinal cosinor method, and noticed that the phase was not lining up well with the data.  I believe phase is calculated incorrectly in compareRhythms.  In taking the arctangent of a ratio in order to get the phase, the coefficient of the cosine of time should be the numerator and the coefficient of the sine of time should be the denominator, not the other way around.  See https://www.youtube.com/watch?v=ZORHu-TWStc (sorry I couldn't find a better reference, but it's short and to the point).  Once I fixed it, my plots looked right.

For reference, here's my plotting function, where `expr_vect` is a vector of gene expression values, `group_fact` is a vector indicating the group for each sample, `cell_line_fact` is a vector indicating the ID for each sample, `time_vect` is time in hours, `amplitudes` is a vector of amplitudes named by group, `phases` is a vector of phases named by group, and `title` is just a title for the plot.

``` r
# Function for plotting gene expression over time
require(ggplot2)

plotCircadianExpression <-
  function(expr_vect, group_fact, cell_line_fact, time_vect,
           amplitudes, phases, title,
           xlab = "Voom normalized expression", ylab = "time"){

    groups <- levels(group_fact)
    means <- tapply(expr_vect, group_fact, mean) # mean expression by group
    
    mintime <- min(time_vect)
    maxtime <- max(time_vect)
    plottimes <- mintime:maxtime

    sinedf <- data.frame(time = rep(plottimes, times = length(groups)),
                         group = rep(groups, each = length(plottimes)))
    sinedf$expression <-
      unlist(lapply(groups, function(x){
        means[x] + amplitudes[x] * sin(plottimes / 12 * pi + phases[x])
      }))
   
    datdf <- data.frame(expression = expr_vect,
                        group = group_fact,
                        cell_line = cell_line_fact,
                        time = time_vect)
    
    ggplot(datdf, aes(x = time, y = expression, color = group)) +
      geom_line(aes(group = cell_line)) +
      geom_point() +
      geom_smooth() +
      geom_line(data = sinedf, linewidth = 1) +
      scale_x_continuous(breaks = seq(mintime, maxtime, by = 8),
                         minor_breaks = seq(mintime + 4,
                                            ifelse(maxtime %% 8 == 0, maxtime - 4, maxtime),
                                            by = 4)) +
      ylab(ylab) + xlab(xlab) +
      ggtitle(title)
  }
```